### PR TITLE
Add documentation for .copilot-ops.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ original issue as input.
 
 Bot behavior can be customized by including a `.copilot-ops.yaml` file in your project's root directory. This file can include the following customization options:
 
-- filesets: define filesets within the config for reference in later issue labels or manually as needed
-- backend: define the AI backend for file generation. Current options are `gpt-3`, `gpt-j`, `opt`, and `bloom`.
-- gpt3: define a specific config for gpt-3 generations. More information can be found [here](https://github.com/djach7/copilot-ops).
-- gptj: define a specific config for gpt-j generations. More information can be found [here](https://github.com/djach7/copilot-ops).
-- bloom: define a specific config for bloom generations. More information can be found [here](https://github.com/djach7/copilot-ops).
+- **backend:** define the AI backend for file generation. Current options are `gpt-3`, `gpt-j`, `opt`, and `bloom`.
+- **filesets:** define filesets within the config for reference in later issue labels or manually as needed.
+- **gpt3:** define a specific config for gpt-3 generations. More information can be found [here](https://github.com/djach7/copilot-ops).
+- **gptj:** define a specific config for gpt-j generations. More information can be found [here](https://github.com/djach7/copilot-ops).
+- **bloom:** define a specific config for bloom generations. More information can be found [here](https://github.com/djach7/copilot-ops).
 
 An example `.copilot-ops.yaml` configuration file:
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,29 @@ This will cause the bot to perform another generation of data using the
 original issue as input.
 <!-- TODO: allow input to be provided on either the issue or pull request -->
 
+### Customizing bot behavior
+
+Bot behavior can be customized by including a `.copilot-ops.yaml` file in your project's root directory. This file can include the following customization options:
+
+- filesets: define filesets within the config for reference in later issue labels or manually as needed
+- backend: define the AI backend for file generation. Current options are `gpt-3`, `gpt-j`, `opt`, and `bloom`.
+- gpt3: define a specific config for gpt-3 generations. More information can be found [here](https://github.com/djach7/copilot-ops).
+- gptj: define a specific config for gpt-j generations. More information can be found [here](https://github.com/djach7/copilot-ops).
+- bloom: define a specific config for bloom generations. More information can be found [here](https://github.com/djach7/copilot-ops).
+
+An example `.copilot-ops.yaml` configuration file:
+
+```yaml
+backend: bloom
+filesets:
+  - name: examples
+    files:
+      - examples/*.yaml
+  - name: stock-data
+    files:
+      - examples/stock-data.yaml
+```
+
 ## Contributions
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) on how to contribute.

--- a/manifests/base/tasks/task.yaml
+++ b/manifests/base/tasks/task.yaml
@@ -119,6 +119,15 @@ spec:
         switchToBranch "${branchName}"
         git reset --hard main
 
+        # Check for copilot config
+        if [ -f ".copilot-ops.yaml" ]
+        then
+          echo "Config file present:"
+          cat ".copilot-ops.yaml"
+        else
+          echo "Config file not found."
+        fi
+
         echo "parsing user request"
         userRequest="$(params.USER_INPUT)" 
         echo "user request: '${userRequest}'"


### PR DESCRIPTION
This pr adds ReadMe documentation for the usage of a .copilot-ops.yaml config file. It also adds a small logging message for handling config files.